### PR TITLE
FIX: fixed a typo in an error message

### DIFF
--- a/index.js
+++ b/index.js
@@ -120,7 +120,7 @@ export default {
     if (typeof options === 'object') {
       config = Object.assign(defaultConfig, options);
       if (!options.clientId) {
-        throw new Error('clientId is require');
+        throw new Error('clientId is required');
       }
     } else {
       throw new TypeError('invalid option type. Object type accepted only');


### PR DESCRIPTION
Changed
```
throw new Error('clientId is require');
```

to 

```
throw new Error('clientId is required');
```